### PR TITLE
Adds support and tests for Project#getByPath

### DIFF
--- a/lib/resources/project.js
+++ b/lib/resources/project.js
@@ -34,5 +34,11 @@ util.inherits(Project, restful.RESTFulResource);
  * @param {Function(err, project)} callback
  */
 Project.prototype.getByPath = function (params, callback) {
-  this.client.request('get', '/project', params, callback);
+  this.client.request('get', '/projects', params, function (err, projects) {
+    if (err) {
+      callback(err);
+    }
+
+    callback(null, projects[0]);
+  });
 };

--- a/test/project.test.js
+++ b/test/project.test.js
@@ -56,16 +56,19 @@ describe('project.test.js', function () {
 
   });
 
-  describe.skip('client.projects.getByPath()', function () {
+  describe('client.projects.getByPath()', function () {
     it('should return a project by path', function (done) {
       client.projects.getByPath({path: 'fengmk2/node-gitlab-test'}, function (err, project) {
         should.not.exists(err);
-        project.id.should.equal(1040);
-        // project.should.have.keys('created_at', 'default_branch', 'description', 'id',
-        //   'issues_enabled', 'merge_requests_enabled', 'name', 'namespace_id',
-        //   'creator_id', 'snippets_enabled', 'public',
-        //   'issues_tracker_id', 'issues_tracker', 'last_activity_at',
-        //   'path', 'private_flag', 'updated_at', 'wall_enabled', 'wiki_enabled');
+        project.path_with_namespace.should.equal('fengmk2/gitlab');
+        project.should.have.keys('id', 'name', 'description', 'default_branch',
+          'owner',
+          'ssh_url_to_repo', 'http_url_to_repo',
+          'web_url',
+          'public', 'path', 'path_with_namespace', 'name_with_namespace', 'namespace',
+          'issues_enabled', 'merge_requests_enabled',
+          'wiki_enabled', 'created_at', 'last_activity_at',
+          'archived', 'visibility_level', 'snippets_enabled');
         done();
       });
     });


### PR DESCRIPTION
This updates the existing Project#getByPath method to point to the `/projects` endpoint and returns the first project found since the Gitlab API doesn't provide a mechanism to return a single project by path. Is there a scenario where more than one project would be returned?
