### PR TITLE
feat: add tags apis

### DIFF
--- a/README.md
+++ b/README.md
@@ -653,6 +653,157 @@ Parameters:
 
 ---
 
+### Repository Tags
+
+https://github.com/gitlabhq/gitlabhq/blob/master/doc/api/tags.md
+
+#### client.repositoryTags.list({id})
+
+Get a list of repository tags from a project.
+
+Parameters:
+
+- id (required) - The ID or NAMESPACE/PROJECT_NAME of a project
+
+```json
+[
+  {
+    "commit": {
+      "author_name": "John Smith",
+      "author_email": "john@example.com",
+      "authored_date": "2012-05-28T04:42:42-07:00",
+      "committed_date": "2012-05-28T04:42:42-07:00",
+      "committer_name": "Jack Smith",
+      "committer_email": "jack@example.com",
+      "id": "2695effb5807a22ff3d138d593fd856244e155e7",
+      "message": "Initial commit",
+      "parents_ids": [
+        "2a4b78934375d7f53875269ffd4f45fd83a84ebe"
+      ]
+    },
+    "release": {
+      "tag_name": "1.0.0",
+      "description": "Amazing release. Wow"
+    },
+    "name": "v1.0.0",
+    "message": null
+  }
+]
+```
+
+#### client.repositoryTags.get({id, tag_name})
+
+Get a specific repository tag determined by its name.
+
+Parameters:
+
+- id (required) - The ID or NAMESPACE/PROJECT_NAME of a project
+- tag_name (required) - The name of the tag
+
+```json
+{
+  "name": "v5.0.0",
+  "message": null,
+  "commit": {
+    "id": "60a8ff033665e1207714d6670fcd7b65304ec02f",
+    "message": "v5.0.0\n",
+    "parent_ids": [
+      "f61c062ff8bcbdb00e0a1b3317a91aed6ceee06b"
+    ],
+    "authored_date": "2015-02-01T21:56:31.000+01:00",
+    "author_name": "Arthur Verschaeve",
+    "author_email": "contact@arthurverschaeve.be",
+    "committed_date": "2015-02-01T21:56:31.000+01:00",
+    "committer_name": "Arthur Verschaeve",
+    "committer_email": "contact@arthurverschaeve.be"
+  },
+  "release": null
+}
+```
+
+#### client.repositoryTags.create({id, tag_name, ref})
+
+Creates a new tag in the repository that points to the supplied ref.
+
+Parameters:
+
+- id (required) - The ID or NAMESPACE/PROJECT_NAME of a project
+- tag_name (required) - The name of the tag
+- ref (required) - Create tag using commit SHA, another tag name, or branch name.
+- message (optional) -  Creates annotated tag.
+- release_description (optional) - Add release notes to the git tag and store it in the GitLab database.
+
+
+```json
+{
+  "commit": {
+    "author_name": "John Smith",
+    "author_email": "john@example.com",
+    "authored_date": "2012-05-28T04:42:42-07:00",
+    "committed_date": "2012-05-28T04:42:42-07:00",
+    "committer_name": "Jack Smith",
+    "committer_email": "jack@example.com",
+    "id": "2695effb5807a22ff3d138d593fd856244e155e7",
+    "message": "Initial commit",
+    "parents_ids": [
+      "2a4b78934375d7f53875269ffd4f45fd83a84ebe"
+    ]
+  },
+  "release": {
+    "tag_name": "1.0.0",
+    "description": "Amazing release. Wow"
+  },
+  "name": "v1.0.0",
+  "message": null
+}
+```
+
+## client.repositoryTags.remove({id, tag_name})
+
+Deletes a tag of a repository with given name.
+
+Parameters:
+
+- `id` (required) - The ID of a project
+- `tag_name` (required) - The name of a tag
+
+## client.repositoryTags.createRelease({id, tag_name, description})
+
+Add release notes to the existing git tag. If there
+already exists a release for the given tag, status code `409` is returned.
+
+Parameters:
+
+- `id` (required) - The ID of a project
+- `tag_name` (required) - The name of a tag
+- `description` (required) - Release notes with markdown support
+
+```json
+{
+  "tag_name": "1.0.0",
+  "description": "Amazing release. Wow"
+}
+```
+
+## client.repositoryTags.updateRelease({id, tag_name, description})
+
+Updates the release notes of a given release.
+
+Parameters:
+
+- `id` (required) - The ID of a project
+- `tag_name` (required) - The name of a tag
+- `description` (required) - Release notes with markdown support
+
+```json
+{
+  "tag_name": "1.0.0",
+  "description": "Amazing release. Wow"
+}
+```
+
+---
+
 ### Issues
 
 https://github.com/gitlabhq/gitlabhq/blob/master/doc/api/issues.md

--- a/README.md
+++ b/README.md
@@ -758,7 +758,7 @@ Parameters:
 }
 ```
 
-## client.repositoryTags.remove({id, tag_name})
+#### client.repositoryTags.remove({id, tag_name})
 
 Deletes a tag of a repository with given name.
 
@@ -767,7 +767,7 @@ Parameters:
 - `id` (required) - The ID of a project
 - `tag_name` (required) - The name of a tag
 
-## client.repositoryTags.createRelease({id, tag_name, description})
+#### client.repositoryTags.createRelease({id, tag_name, description})
 
 Add release notes to the existing git tag. If there
 already exists a release for the given tag, status code `409` is returned.
@@ -785,7 +785,7 @@ Parameters:
 }
 ```
 
-## client.repositoryTags.updateRelease({id, tag_name, description})
+#### client.repositoryTags.updateRelease({id, tag_name, description})
 
 Updates the release notes of a given release.
 

--- a/lib/resources/index.js
+++ b/lib/resources/index.js
@@ -26,6 +26,8 @@ module.exports = {
 
   repositoryBranches: require('./repository_branch'),
 
+  repositoryTags: require('./repository_tag'),
+
   repositoryFiles: {
     resourcePath: '/projects/:id/repository/files'
   },

--- a/lib/resources/repository_tag.js
+++ b/lib/resources/repository_tag.js
@@ -1,0 +1,22 @@
+'use strict';
+
+var util = require('util')
+var restful = require('restful-client')
+
+function Tag(client) {
+  this.constructor.super_.call(this, client, '/projects/:id/repository/tags', 'tag_name');
+}
+
+util.inherits(Tag, restful.RESTFulResource);
+
+Tag.prototype.createRelease = function (params, callback) {
+  this.client.request('post', this.onePath + '/release', params, callback);
+  return this;
+};
+
+Tag.prototype.updateRelease = function (params, callback) {
+  this.client.request('put', this.onePath + '/release', params, callback);
+  return this;
+};
+
+module.exports = Tag;

--- a/test/repository.test.js
+++ b/test/repository.test.js
@@ -235,7 +235,7 @@ describe.skip('repository.test.js', function () {
       });
     });
   });
-  
+
   describe('client.repository.archive()', function () {
     it('should return archive file', function (done) {
       client.repository.archive({id: 55045, sha: '946579807281bd26b75b91986c78f15ad0bd40f7'}, function (err, raw) {
@@ -248,7 +248,7 @@ describe.skip('repository.test.js', function () {
       });
     });
   });
-  
+
   describe('client.repository.compare()', function () {
     it('should return diffs', function (done) {
       client.repository.compare({id: 55045, to: 'master', from: '946579807281bd26b75b91986c78f15ad0bd40f7'}, function (err, diffs) {
@@ -260,5 +260,5 @@ describe.skip('repository.test.js', function () {
         done();
       });
     });
-  });   
+  });
 });

--- a/test/repository_tag.test.js
+++ b/test/repository_tag.test.js
@@ -1,0 +1,187 @@
+'use strict';
+
+/**
+ * Module dependencies.
+ */
+
+var should = require('should');
+var objectid = require('objectid');
+var defaultConfig = require('./config');
+var gitlab = require('..');
+
+// account: https://gitlab.com/liangduan
+var accessToken = 'x_hv_ZfLLpwsURoG47Ti';
+// repo: https://gitlab.com/liangduan/gitlab-test
+var projectId = encodeURIComponent('liangduan/gitlab-test');
+
+function createConfig() {
+  var config = {};
+
+  for (var key in defaultConfig) {
+    if (defaultConfig.hasOwnProperty(key)) {
+      config[key] = defaultConfig[key];
+    }
+  }
+
+  config.privateToken = accessToken;
+  return config;
+}
+
+var config = createConfig();
+var client = gitlab.create(config);
+
+function createTag() {
+  var tag_name = 'tag-test-' + objectid();
+
+  return new Promise(function(resolve, reject) {
+    client.repositoryTags.create({
+      id: projectId,
+      tag_name: tag_name,
+      ref: 'master',
+    }, function(err, tag) {
+      if (err) {
+        reject(err);
+        return;
+      }
+      resolve(tag_name);
+    });
+  })
+}
+
+function createRelease(tag_name, description) {
+  return new Promise(function(resolve, reject) {
+    client.repositoryTags.createRelease({
+      id: projectId,
+      tag_name: tag_name,
+      description: description,
+    }, function(err) {
+      if (err) {
+        reject(err);
+        return;
+      }
+
+      resolve(tag_name);
+    })
+  })
+}
+
+describe('repository_tag.test.js', function () {
+  it('should list all tags of a project', function(done) {
+    client.repositoryTags.list({ id: projectId }, function(err, tags) {
+      should.not.exists(err);
+      should.exists(tags);
+      tags.should.be.instanceof(Array);
+      tags.forEach(function (item) {
+        item.should.have.keys('name', 'message', 'commit', 'release');
+      });
+      done();
+    });
+  });
+
+  it('should get a specific tag by tag_name', function(done) {
+    client.repositoryTags.get({ id: projectId, tag_name: '1' }, function(err, tag) {
+      should.not.exists(err);
+      should.exists(tag);
+      tag.should.be.instanceof(Object);
+      tag.should.have.keys('name', 'message', 'commit', 'release');
+      done();
+    });
+  });
+
+  it('should create a new tag in the repository that points to the supplied ref', function(done) {
+    client.repositoryTags.create({
+      id: projectId,
+      tag_name: 'tag-test-' + objectid(),
+      ref: 'master',
+    }, function(err, tag) {
+      should.not.exists(err);
+      should.exists(tag);
+      tag.should.be.instanceof(Object);
+      tag.should.have.keys('name', 'message', 'commit', 'release');
+      done();
+    });
+  });
+
+  it('should delete a tag by its tag_name', function(done) {
+    var create = createTag();
+
+    create.then(function(tag_name) {
+      client.repositoryTags.remove({
+        id: projectId,
+        tag_name: tag_name,
+      }, function(err, tag) {
+        should.not.exists(err);
+        should.exists(tag);
+        tag.should.be.instanceof(Object);
+        tag.should.have.keys('tag_name');
+        done();
+      });
+    }).catch(done);
+  });
+
+  it('should add release notes to the existing git tag.', function(done) {
+    var create = createTag();
+    var description = 'Amazing release. Wow';
+
+    create.then(function(tag_name) {
+      client.repositoryTags.createRelease({
+        id: projectId,
+        tag_name: tag_name,
+        description: description,
+      }, function(err, tag) {
+        should.not.exists(err);
+        should.exists(tag);
+        tag.should.be.instanceof(Object);
+        tag.should.have.keys('tag_name', 'description');
+        tag.tag_name.should.equal(tag_name);
+        tag.description.should.equal(description);
+        done();
+      });
+    }).catch(done);
+  });
+
+  it('should add release notes to the existing git tag.', function(done) {
+    var create = createTag();
+    var description = 'Amazing release. Wow';
+
+    create.then(function(tag_name) {
+      client.repositoryTags.createRelease({
+        id: projectId,
+        tag_name: tag_name,
+        description: description,
+      }, function(err, tag) {
+        should.not.exists(err);
+        should.exists(tag);
+        tag.should.be.instanceof(Object);
+        tag.should.have.keys('tag_name', 'description');
+        tag.tag_name.should.equal(tag_name);
+        tag.description.should.equal(description);
+        done();
+      });
+    }).catch(done);
+  });
+
+  it('should update release notes to the existing git tag.', function(done) {
+    var create = createTag();
+    var description = 'Amazing release. Wow';
+    var anotherDescription = 'Another description';
+
+    create.then(function(tag_name) {
+      return createRelease(tag_name, description);
+    }).then(function(tag_name) {
+      client.repositoryTags.updateRelease({
+        id: projectId,
+        tag_name: tag_name,
+        description: anotherDescription,
+      }, function(err, tag) {
+        should.not.exists(err);
+        should.exists(tag);
+        tag.should.be.instanceof(Object);
+        tag.should.have.keys('tag_name', 'description');
+        tag.tag_name.should.equal(tag_name);
+        tag.description.should.equal(anotherDescription);
+        done();
+      });
+    }).catch(done);
+  });
+});


### PR DESCRIPTION
It's impossible to create isolated new projects by api for the tests of tags, as this [issue](https://forum.gitlab.com/t/creating-master-branch-via-gitlab-api/2569) is not resolved. Therefore, I have created another repository with initial code pushing and use it for testing.

Please inform me if you don't think this is proper.