### PR TITLE
file_path parameter was missing

### DIFF
--- a/lib/resources/index.js
+++ b/lib/resources/index.js
@@ -27,7 +27,7 @@ module.exports = {
   repositoryBranches: require('./repository_branch'),
 
   repositoryFiles: {
-    resourcePath: '/projects/:id/repository/files'
+    resourcePath: '/projects/:id/repository/files/:file_path'
   },
 
   mergeRequests: require('./merge_request'),


### PR DESCRIPTION
https://github.com/gitlabhq/gitlabhq/blob/master/doc/api/repository_files.md specifies that file_path is a part of the URL path, not a parameter.

Note that it has to be URL-encoded, e.g.
`client.repositoryFiles.get({ id: 123, ref: 'master', file_path: encodeURIComponent('dir/file.json') });`
