### PR TITLE
#44: added possibility to set request header

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,30 @@ client.milestones.list({id: 1})
 
 @see [Gitlab API document](https://github.com/gitlabhq/gitlabhq/tree/master/doc/api).
 
+### Header
+
+#### client.addHeader(key, value)
+
+Set a header (for example the SUDO header) which will be added to every request.
+
+```js
+client.addHeader('SUDO', 'johnd');
+
+// The note is added by user 'johnd'
+client.issues.createNote({
+  issue_id: 'issue_id',
+  id: 'project_id',
+  body: 'Note from user johnd.'
+});
+```
+#### client.removeHeader(key)
+
+Remove a set header value
+
+```js
+client.removeHeader('SUDO');
+```
+
 ### Project
 
 https://github.com/gitlabhq/gitlabhq/blob/master/doc/api/projects.md

--- a/lib/gitlab.js
+++ b/lib/gitlab.js
@@ -40,12 +40,42 @@ function Gitlab(options) {
   this.merge_requests = this.mergeRequests;
   // members => projectMembers
   this.members = this.projectMembers;
+  // headers
+  this.headers = {};
 }
 
 util.inherits(Gitlab, RESTFulClient);
 
+/**
+ * @method addHeader
+ * Add a header to the headers object
+ * 
+ * @param {string} key The header key to set 
+ * @param {string} value The header value to set 
+ */
+var addHeader = function(key, value) {
+  this.headers[key] = value;
+}
+
+/**
+ * @method removeHeader
+ * Removes a header from the headers object
+ * 
+ * @param {string} key The key of the header to remove
+ */
+var removeHeader = function(key) {
+  if (this.headers[key] !== undefined) {
+    delete this.headers[key];
+  }
+}
+
 Gitlab.prototype.setAuthentication = function (req) {
   req.params.data.private_token = req.params.data.private_token || this.privateToken;
+
+  for (let prop in this.headers) {
+    req.params.headers[prop] = this.headers[prop];
+  }
+
   return req;
 };
 
@@ -55,10 +85,20 @@ Gitlab.create = function (options) {
 
 Gitlab.createPromise = function (options) {
   var client = Gitlab.create(options);
-  return require('./promisify')(client);
+  var promisified = require('./promisify')(client);
+
+  promisified.addHeader = addHeader.bind(client);
+  promisified.removeHeader = removeHeader.bind(client);
+
+  return promisified;
 };
 
 Gitlab.createThunk = function (options) {
   var client = Gitlab.create(options);
-  return require('./thunkify')(client);
+  var thunked = require('./thunkify')(client);
+
+  thunked.addHeader = addHeader.bind(client);
+  thunked.removeHeader = removeHeader.bind(client);  
+  
+  return thunked;
 };


### PR DESCRIPTION
I have added the possibility to add header to the requests. Hope you like it.

I needed this feature for setting the api sudo to my requests to act as different users.

I'm not shure if my code meets your style guide but i would be happy if you could adopt this feature. 