### PR TITLE
Jshint to eslint

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,4 @@
+node_modules/*
+coverage/*
+.tmp/*
+.git/*

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,65 @@
+{
+  "extends": 'usecases/usecase/nodejs',
+  "env": {
+    "browser": true,
+    "node": true
+  },
+  "globals": {
+    "describe": true,
+    "it": true,
+    "before": true,
+    "afterEach": true,
+    "beforeEach": true,
+    "after": true
+  },
+  "rules": {
+    "no-bitwise": 2,
+    "camelcase": 0,
+    "curly": 2,
+    "eqeqeq": 2,
+    "guard-for-in": 0,
+    "wrap-iife": 0,
+    "indent": 0,
+    "no-use-before-define": 0,
+    "new-cap": 0,
+    "no-caller": 2,
+    "no-empty": 2,
+    "no-new": 0,
+    "no-plusplus": 0,
+    "quotes": 0,
+    "no-undef": 2,
+    "no-unused-vars": 0,
+    "strict": 0,
+    "max-params": 0,
+    "max-depth": 0,
+    "max-statements": 0,
+    "complexity": 0,
+    "max-len": 0,
+    "semi": 0,
+    "no-cond-assign": [
+      2,
+      "except-parens"
+    ],
+    "no-debugger": 0,
+    "no-eq-null": 0,
+    "no-eval": 0,
+    "no-unused-expressions": 2,
+    "block-scoped-var": 0,
+    "no-iterator": 0,
+    "linebreak-style": 2,
+    "comma-style": [
+      2,
+      "first"
+    ],
+    "no-loop-func": 0,
+    "no-multi-str": 2,
+    "no-proto": 0,
+    "no-script-url": 0,
+    "no-shadow": 0,
+    "dot-notation": 2,
+    "no-new-func": 0,
+    "no-new-wrappers": 0,
+    "no-invalid-this": 2,
+    "require-yield": 2
+  }
+}

--- a/History.md
+++ b/History.md
@@ -1,4 +1,10 @@
 
+1.6.1 / 2018-11-27
+==================
+
+**fixes**
+  * [[`4789c4a`](http://github.com/repo-utils/gitlab/commit/4789c4a9595781ac7a3c202e7fc3ea91a467ba84)] - fix: debug CVE-2017-16137 security fix (#50) (fengmk2 <<fengmk2@gmail.com>>)
+
 1.6.0 / 2017-01-11
 ==================
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "test-cov": "node --harmony node_modules/.bin/istanbul cover node_modules/.bin/_mocha -- -r co-mocha -t 40000 test/*.test.js",
     "test-travis": "node --harmony node_modules/.bin/istanbul cover node_modules/.bin/_mocha --report lcovonly -- -r co-mocha -t 40000 test/*.test.js",
     "jshint": "jshint .",
+    "eslint": "eslint .", 
+    "eslint:fix": "eslint --fix .",
     "autod": "autod -w --prefix '~'",
     "cnpm": "npm install --registry=https://registry.npm.taobao.org",
     "contributors": "contributors -f plain -o AUTHORS"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-gitlab",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "description": "Gitlab API nodejs client.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
### Switching from JSHint to ESLint
Start with the following installations

`$ npm install eslint --save-dev`
`$ npm install eslint-config-usecases --save-dev`
`$ npm install -g polyjuice`
`$ polyjuice --jshint .jshintrc> .eslintrc` for mor details of polyjuice [cliquez ici](https://eslint.org/docs/user-guide/migrating-from-jscs)

#
Automatic conversion from jshint to eslint and automatic creation of .eslintrc
#
And then add extends: `'usecases / usecase / nodejs'` in .eslintrc
#
Then go to `package.json` and add in the script:
#
`"eslint": "eslint.",
"eslint: fix": "eslint --fix."` 
# 
To fix some errors automatically or by replacing "jshint": "jshint." by these two last ones.
#
For the .eslintignore file, manually create the .jshintignore file and add these lines :
#

```bash
node_modules / *
coverage / *
tmp / *
.git / *
```